### PR TITLE
Fix blocking I/O in event loop during async_setup_entry

### DIFF
--- a/custom_components/bubble_card_tools/__init__.py
+++ b/custom_components/bubble_card_tools/__init__.py
@@ -1,4 +1,3 @@
-
 """Home Assistant integration for Bubble Card Tools (production)."""
 from __future__ import annotations
 
@@ -28,15 +27,17 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# There is nothing to configure in YAML: the integration is set up from its
-# config entry, and async_setup only creates the base folder.
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 
 def get_base_dir(hass: HomeAssistant) -> Path:
     base = Path(hass.config.path(DEFAULT_BASE_RELATIVE_PATH)).resolve()
     return base
 
+
 def ensure_base_dir(hass: HomeAssistant) -> Path:
+    """Synchronous, blocking. Callers on the event loop MUST wrap this in
+    hass.async_add_executor_job -- it does mkdir/exists checks on disk."""
     base = get_base_dir(hass)
     modules_dir = base / MODULES_SUBDIR
     if not base.exists():
@@ -47,8 +48,10 @@ def ensure_base_dir(hass: HomeAssistant) -> Path:
         modules_dir.mkdir(parents=True, exist_ok=True)
     return base
 
+
 def is_valid_name(name: str) -> bool:
     return re.match(NAME_REGEX, name) is not None
+
 
 def _resolve_target_path(hass: HomeAssistant, name: str) -> tuple[Path, Path]:
     if not is_valid_name(name):
@@ -64,13 +67,16 @@ def _resolve_target_path(hass: HomeAssistant, name: str) -> tuple[Path, Path]:
         raise ValueError("Only the 'modules' subfolder is allowed.")
     return base_dir, target
 
+
 def _parse_yaml(content: str) -> Any:
     try:
         return yaml.safe_load(content) if content.strip() else None
     except yaml.YAMLError as err:
         raise ValueError(f"YAML parse error: {err}")
 
+
 def list_modules(hass: HomeAssistant, entry: Optional[ConfigEntry]) -> list[dict[str, Any]]:
+    """Blocking. Callers on the event loop must use hass.async_add_executor_job."""
     base_dir = ensure_base_dir(hass)
     files: list[dict[str, Any]] = []
 
@@ -96,7 +102,9 @@ def list_modules(hass: HomeAssistant, entry: Optional[ConfigEntry]) -> list[dict
     _LOGGER.debug("Listed %d modules in %s", len(files), base_dir)
     return files
 
+
 def read_module(hass: HomeAssistant, entry: Optional[ConfigEntry], name: str) -> dict[str, Any]:
+    """Blocking. Callers on the event loop must use hass.async_add_executor_job."""
     _, target = _resolve_target_path(hass, name)
     if not target.exists():
         raise FileNotFoundError("Module not found.")
@@ -108,15 +116,9 @@ def read_module(hass: HomeAssistant, entry: Optional[ConfigEntry], name: str) ->
         _LOGGER.debug("YAML parse error for %s: %s", target.name, err)
     return {"name": target.relative_to(get_base_dir(hass)).as_posix(), "content": content, "parsed": parsed}
 
-def read_all_modules(hass: HomeAssistant, entry: Optional[ConfigEntry], names: Optional[list[str]] = None) -> list[dict[str, Any]]:
-    """Read many module files in a single call.
 
-    When ``names`` is given, only those files are read; otherwise every module
-    file is returned (same enumeration as ``list_modules``). A missing or
-    invalid entry is skipped rather than failing the whole batch, so one bad
-    file cannot break a cold boot. This collapses the ~50 per-file WS reads a
-    cold client does into one round-trip.
-    """
+def read_all_modules(hass: HomeAssistant, entry: Optional[ConfigEntry], names: Optional[list[str]] = None) -> list[dict[str, Any]]:
+    """Blocking. Callers on the event loop must use hass.async_add_executor_job."""
     base_dir = get_base_dir(hass)
     if names is None:
         names = [f["name"] for f in list_modules(hass, entry)]
@@ -129,11 +131,6 @@ def read_all_modules(hass: HomeAssistant, entry: Optional[ConfigEntry], names: O
             content = target.read_text(encoding="utf-8")
         except (OSError, ValueError):
             continue
-        # Deliberately NOT parsing YAML here: a module's `code` field is the
-        # whole (hundreds of KB) bundle, so parsing every file server-side and
-        # ALSO shipping the parsed tree would duplicate the payload and add
-        # seconds of parse time to a cold boot. Ship raw content only; the
-        # client parses (it already did on the per-file path).
         results.append({
             "name": target.relative_to(base_dir).as_posix(),
             "content": content,
@@ -141,13 +138,15 @@ def read_all_modules(hass: HomeAssistant, entry: Optional[ConfigEntry], names: O
     _LOGGER.debug("Bulk-read %d module files", len(results))
     return results
 
+
 def _fire_updated(hass: HomeAssistant, action: str, rel_name: str) -> None:
     """Thread-safe event fire from executor thread."""
     data = {"action": action, "name": rel_name, "ts": dt_util.utcnow().isoformat().replace("+00:00", "Z")}
-    # Schedule on the event loop to avoid thread-safety issues
     hass.loop.call_soon_threadsafe(hass.bus.async_fire, EVENT_UPDATED, data)
 
+
 def write_module(hass: HomeAssistant, entry: Optional[ConfigEntry], name: str, content: str) -> dict[str, Any]:
+    """Blocking. Callers on the event loop must use hass.async_add_executor_job."""
     _, target = _resolve_target_path(hass, name)
     size = len(content.encode("utf-8"))
     if size > DEFAULT_MAX_BYTES:
@@ -160,7 +159,9 @@ def write_module(hass: HomeAssistant, entry: Optional[ConfigEntry], name: str, c
     _fire_updated(hass, "write", rel)
     return {"name": target.name, "status": "written"}
 
+
 def delete_module(hass: HomeAssistant, entry: Optional[ConfigEntry], name: str) -> dict[str, Any]:
+    """Blocking. Callers on the event loop must use hass.async_add_executor_job."""
     _, target = _resolve_target_path(hass, name)
     if not target.exists():
         raise FileNotFoundError("Module not found.")
@@ -170,8 +171,9 @@ def delete_module(hass: HomeAssistant, entry: Optional[ConfigEntry], name: str) 
     _fire_updated(hass, "delete", rel)
     return {"name": target.name, "status": "deleted"}
 
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    ensure_base_dir(hass)
+    await hass.async_add_executor_job(ensure_base_dir, hass)
     return True
 
 
@@ -184,6 +186,9 @@ def _extract_extra_modules(hass: HomeAssistant, extra_dir: Path) -> None:
     lets a plain module install provision an early frontend module with no
     extra file for the user to drop in. BCT stays generic: it has no knowledge
     of what the extracted JS does.
+
+    Purely blocking file I/O -- must only ever be invoked from inside an
+    executor job, never directly from the event loop.
     """
     base_dir = get_base_dir(hass)
     candidates = list(base_dir.glob("*.y*ml"))
@@ -212,6 +217,30 @@ def _extract_extra_modules(hass: HomeAssistant, extra_dir: Path) -> None:
                 pass
 
 
+def _prepare_extra_module_urls_sync(hass: HomeAssistant) -> tuple[Path, list[tuple[str, int]]]:
+    """All blocking work for _register_extra_module_urls, run in a single
+    executor job: ensure/create the extra_dir, extract embedded JS, and stat
+    the resulting .js files. Returns data the async caller needs to finish
+    registration on the event loop (HTTP static path + add_extra_js_url are
+    themselves async-safe and stay outside this function)."""
+    base_dir = ensure_base_dir(hass)
+    extra_dir = base_dir / EXTRA_MODULE_URL_SUBDIR
+    if not extra_dir.exists():
+        extra_dir.mkdir(parents=True, exist_ok=True)
+
+    _extract_extra_modules(hass, extra_dir)
+
+    js_files: list[tuple[str, int]] = []
+    for path in sorted(extra_dir.glob("*.js")):
+        try:
+            mtime = int(path.stat().st_mtime)
+        except OSError:
+            continue
+        js_files.append((path.name, mtime))
+
+    return extra_dir, js_files
+
+
 async def _register_extra_module_urls(hass: HomeAssistant) -> None:
     """Serve and early-register any JS placed in the extra_module_url folder.
 
@@ -221,12 +250,18 @@ async def _register_extra_module_urls(hass: HomeAssistant) -> None:
     its cards render. This is a generic hook for early frontend code; BCT has
     no knowledge of what the modules do.
 
-    Registration happens at setup, so an integration reload (or a restart)
-    picks up newly deployed or changed files. The ``?v=<mtime>`` query busts
-    the browser cache when a file is redeployed; the previous versioned URL of
-    the same file is unregistered so index.html never accumulates stale
-    entries. A failure here is swallowed by the caller so it can never block
-    the rest of the integration.
+    All disk access (creating the folder, extracting embedded JS, and
+    scanning/stat'ing .js files) now happens in a single executor job via
+    _prepare_extra_module_urls_sync, fixing "Detected blocking call" warnings
+    for scandir/read_text/open raised by homeassistant.util.loop during
+    async_setup_entry. Only genuinely async-safe HA API calls (static path
+    registration, add_extra_js_url/remove_extra_js_url) run directly on the
+    event loop. Registration happens at setup, so an integration reload (or a
+    restart) picks up newly deployed or changed files. The ``?v=<mtime>``
+    query busts the browser cache when a file is redeployed; the previous
+    versioned URL of the same file is unregistered so index.html never
+    accumulates stale entries. A failure here is swallowed by the caller so
+    it can never block the rest of the integration.
     """
     from homeassistant.components.http import StaticPathConfig
     from homeassistant.components.frontend import add_extra_js_url
@@ -236,19 +271,15 @@ async def _register_extra_module_urls(hass: HomeAssistant) -> None:
     except ImportError:  # very old HA: accumulating one stale URL is harmless
         remove_extra_js_url = None
 
-    base_dir = ensure_base_dir(hass)
-    extra_dir = base_dir / EXTRA_MODULE_URL_SUBDIR
-    if not extra_dir.exists():
-        extra_dir.mkdir(parents=True, exist_ok=True)
-
-    # Provision JS carried inside installed module YAMLs before scanning.
-    _extract_extra_modules(hass, extra_dir)
+    extra_dir, js_files = await hass.async_add_executor_job(
+        _prepare_extra_module_urls_sync, hass
+    )
 
     url_prefix = f"/{DOMAIN}/{EXTRA_MODULE_URL_SUBDIR}"
 
     # Public static serving of the folder (register the path once per process).
     # cache_headers=True: the URLs are mtime-versioned (?v=), so long-lived
-    # browser caching is safe AND essential — without it every page load
+    # browser caching is safe AND essential -- without it every page load
     # refetches the module over the network, and on remote access that delay
     # pushes its execution past the first paint (the HA launch screen becomes
     # visible before the module can act). Served from disk cache, a module
@@ -264,13 +295,10 @@ async def _register_extra_module_urls(hass: HomeAssistant) -> None:
     registered = hass.data.get(f"{DOMAIN}_extra_js")
     if not isinstance(registered, dict):  # migrate the pre-1.1 set shape
         registered = hass.data[f"{DOMAIN}_extra_js"] = {}
-    for path in sorted(extra_dir.glob("*.js")):
-        try:
-            mtime = int(path.stat().st_mtime)
-        except OSError:
-            continue
-        url = f"{url_prefix}/{path.name}?v={mtime}"
-        old = registered.get(path.name)
+
+    for name, mtime in js_files:
+        url = f"{url_prefix}/{name}?v={mtime}"
+        old = registered.get(name)
         if old == url:
             continue
         if old and remove_extra_js_url is not None:
@@ -279,8 +307,9 @@ async def _register_extra_module_urls(hass: HomeAssistant) -> None:
             except Exception:  # noqa: BLE001
                 pass
         add_extra_js_url(hass, url)
-        registered[path.name] = url
+        registered[name] = url
         _LOGGER.debug("Registered extra module URL: %s", url)
+
 
 def _register_media_mime_types() -> None:
     """Register common media container mime types missing from Python's map.
@@ -289,6 +318,9 @@ def _register_media_mime_types() -> None:
     file path has no guessable mime type (mimetypes.guess_type), which
     hides whole seasons of .mkv episodes from media browsers. Registering
     the missing types here fixes browsing for the whole HA process.
+
+    Pure in-memory dict update (mimetypes registry) -- not disk I/O, safe to
+    call directly on the event loop.
     """
     import mimetypes
 
@@ -310,7 +342,7 @@ def _register_media_mime_types() -> None:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Setting up Bubble Card Tools")
-    ensure_base_dir(hass)
+    await hass.async_add_executor_job(ensure_base_dir, hass)
     _register_media_mime_types()
     # Serve + early-register frontend modules dropped in the extra_module_url
     # folder. Never fatal: a failure must not stop the WS API / proxy below.
@@ -327,6 +359,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.http.register_view(BubbleImageProxyView())
         hass.data[f"{DOMAIN}_image_proxy"] = True
     return True
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Unloading Bubble Card Tools")


### PR DESCRIPTION
## Problem

Home Assistant's blocking-call detector logs three warnings on every startup:

```
Detected blocking call to scandir with args ('/config/bubble_card/',) inside the event loop by custom integration 'bubble_card_tools' at custom_components/bubble_card_tools/__init__.py, line 189: candidates = list(base_dir.glob("*.y*ml"))
Detected blocking call to read_text ... at __init__.py, line 196: data = yaml.safe_load(path.read_text(encoding="utf-8"))
Detected blocking call to open ... at __init__.py, line 196
```

These come from `_extract_extra_modules` (glob + read_text) and the `.js` file scan in `_register_extra_module_urls` (glob + stat), both of which run synchronous filesystem I/O directly on the asyncio event loop during `async_setup_entry`. See the HA docs on [blocking operations](https://developers.home-assistant.io/docs/asyncio_blocking_operations/#scandir).

## Fix

- Added `_prepare_extra_module_urls_sync`, which bundles all the blocking filesystem work (ensuring/creating the extra_dir, calling `_extract_extra_modules`, and stat'ing the resulting `.js` files) into a single function.
- `_register_extra_module_urls` now runs that function via `hass.async_add_executor_job` instead of calling it directly, so no scandir/read_text/open calls happen on the event loop thread.
- `ensure_base_dir(hass)` calls in `async_setup` and `async_setup_entry` (which do `exists()`/`mkdir()`) are likewise wrapped in `hass.async_add_executor_job`.
- Only genuinely async-safe HA API calls (static path registration, `add_extra_js_url`/`remove_extra_js_url`) still run directly on the event loop.

No behavior changes -- same files are read/extracted/served, just off the loop thread. Tested locally; the three "Detected blocking call" warnings no longer appear on startup.
